### PR TITLE
add ipconfig module

### DIFF
--- a/Server/modules/ipconfig.py
+++ b/Server/modules/ipconfig.py
@@ -1,0 +1,11 @@
+class STModule:
+    def __init__(self):
+        self.name = 'ipconfig'
+        self.description = 'Enumerates network interfaces.'
+        self.author = 'daddycocoaman'
+        self.options = {}
+
+    def payload(self):
+        with open('modules/src/ipconfig.py', 'r') as module_src:
+            src = module_src.read()
+            return src.encode()

--- a/Server/modules/src/ipconfig.py
+++ b/Server/modules/src/ipconfig.py
@@ -1,0 +1,56 @@
+import System
+import System.Net.IPAddress as IPAddress
+import System.Net.NetworkInformation as NetworkInformation
+
+def convertNumToIP(ipNum):
+    ipBytes = IPAddress.Parse(ipNum.ToString()).GetAddressBytes()
+    System.Array.Reverse(ipBytes)
+    return IPAddress(ipBytes).ToString()
+
+def configSummary():
+    gp = NetworkInformation.IPGlobalProperties.GetIPGlobalProperties()
+    details = (gp.HostName, gp.DomainName, gp.NodeType, gp.DhcpScopeName, gp.IsWinsProxy)
+    summary = """\nComputer Name: {0}
+    Domain Name: {1}
+    Node Type: {2}
+    DHCP Scope: {3}
+    WINS Proxy: {4}\n""".format(*details)
+    return summary
+
+def interfaceSummary(iface):
+    properties = iface.GetIPProperties()
+    physAddr = iface.GetPhysicalAddress().ToString()
+    physAddr = ":".join(x+y for x,y in zip(physAddr[::2], physAddr[1::2]))
+    uniAddrs = ", ".join([uni.Address.ToString() for uni in properties.UnicastAddresses if uni.Address.AddressFamily.ToString() == "InterNetwork"])
+    multiAddrs = ", ".join([multi.Address.ToString() for multi in properties.MulticastAddresses if multi.Address.AddressFamily.ToString() == "InterNetwork"])
+    dhcpAddrs = ", ".join([convertNumToIP(dhcp.Address) for dhcp in properties.DhcpServerAddresses])
+    
+    try:
+        dnsAddrs = ", ".join([convertNumToIP(dns.Address) for dns in properties.DnsAddresses])
+    except Exception:
+        dnsAddrs = ""
+
+    gwAddrs = ", ".join([gw.Address.ToString() for gw in properties.GatewayAddresses])
+
+    details = (iface.Name, iface.NetworkInterfaceType, iface.Description, physAddr, uniAddrs, multiAddrs, dhcpAddrs, dnsAddrs, properties.DnsSuffix, gwAddrs)
+    summary = '''\nName: {0}
+    Type: {1}
+    Description: {2}
+    Physical Address: {3}
+    IP Addresses: {4}
+    Multicast Addresses: {5}
+    DHCP Addresses: {6}
+    DNS Addresses: {7}
+    DNS Suffix: {8}
+    Gateway Addresses: {9}\n'''.format(*details)
+    return summary
+
+def ipconfig():
+    response = configSummary()
+    interfaces = NetworkInformation.NetworkInterface.GetAllNetworkInterfaces()
+    for iface in interfaces:
+        response += interfaceSummary(iface)
+
+    print response
+
+ipconfig()

--- a/Server/modules/src/ipconfig.py
+++ b/Server/modules/src/ipconfig.py
@@ -51,6 +51,6 @@ def ipconfig():
     for iface in interfaces:
         response += interfaceSummary(iface)
 
-    print response
+    return response
 
-ipconfig()
+print ipconfig()


### PR DESCRIPTION
In the face of yo interface without running the ifconfig binary.

```ST (modules) ≫ use ipconfig                                                                                                                                                                                                                        
ST (modules)(ipconfig) ≫ run all                                                                                                                                                                                                                   
[+] ee00660a-6966-4eb3-8e7d-4f3dfb46c0c2 returned job result (id: APahTXIv)

Computer Name: DESKTOP-1HKCUVT
    Domain Name: 
    Node Type: Hybrid
    DHCP Scope: 
    WINS Proxy: False

Name: Ethernet0
    Type: Ethernet
    Description: Intel(R) 82574L Gigabit Network Connection
    Physical Address: 00:0C:29:35:91:91
    IP Addresses: 192.168.1.58
    Multicast Addresses: 224.0.0.1, 224.0.0.251, 224.0.0.252, 239.255.255.250
    DHCP Addresses: 192.168.1.1
    DNS Addresses: 192.168.1.30, 192.168.1.1
    DNS Suffix: 
    Gateway Addresses: 192.168.1.1

Name: Bluetooth Network Connection
    Type: Ethernet
    Description: Bluetooth Device (Personal Area Network)
    Physical Address: AC:7B:A1:47:EA:2C
    IP Addresses: 169.254.129.153
    Multicast Addresses: 224.0.0.1
    DHCP Addresses: 
    DNS Addresses: 
    DNS Suffix: 
    Gateway Addresses: 

Name: Loopback Pseudo-Interface 1
    Type: Loopback
    Description: Software Loopback Interface 1
    Physical Address: 
    IP Addresses: 127.0.0.1
    Multicast Addresses: 239.255.255.250
    DHCP Addresses: 
    DNS Addresses: 
    DNS Suffix: 
    Gateway Addresses: 
```