### PR TITLE
add systeminfo module

### DIFF
--- a/Server/modules/src/systeminfo.py
+++ b/Server/modules/src/systeminfo.py
@@ -1,0 +1,15 @@
+import System.DateTime as DateTime
+import System.Environment as Env
+import System.Diagnostics as Diagnostics
+
+def getSystemInfo():
+    summary = "\nHost: \t{0}\n".format(Env.MachineName)
+    summary += "OS: \t{0} {1}\n".format(Env.OSVersion.Platform, Diagnostics.FileVersionInfo.GetVersionInfo(Env.SystemDirectory + "\\kernel32.dll").ProductVersion)
+    summary += "64-Bit: {0}\n".format(Env.Is64BitOperatingSystem)
+    summary += "Domain: {0}\n".format(Env.UserDomainName)
+    summary += "User: \t{0}\n".format(Env.UserName)
+    summary += "Date: \t{0}\n".format(DateTime.Now.ToString())
+    print summary
+
+getSystemInfo()
+

--- a/Server/modules/src/systeminfo.py
+++ b/Server/modules/src/systeminfo.py
@@ -9,7 +9,7 @@ def getSystemInfo():
     summary += "Domain: {0}\n".format(Env.UserDomainName)
     summary += "User: \t{0}\n".format(Env.UserName)
     summary += "Date: \t{0}\n".format(DateTime.Now.ToString())
-    print summary
+    return summary
 
-getSystemInfo()
+print getSystemInfo()
 

--- a/Server/modules/systeminfo.py
+++ b/Server/modules/systeminfo.py
@@ -1,0 +1,11 @@
+class STModule:
+    def __init__(self):
+        self.name = 'systeminfo'
+        self.description = 'Enumerates basic system information.'
+        self.author = 'daddycocoaman'
+        self.options = {}
+
+    def payload(self):
+        with open('modules/src/systeminfo.py', 'r') as module_src:
+            src = module_src.read()
+            return src.encode()


### PR DESCRIPTION
Systeminfo with similar information to meterpreter.

```
ST (modules)(ipconfig) ≫ use systeminfo                                                                                                                                                                                                            
ST (modules)(systeminfo) ≫ run all                                                                                                                                                                                                                 
[+] ee00660a-6966-4eb3-8e7d-4f3dfb46c0c2 returned job result (id: tyFjfGNB)

Host: 	DESKTOP-1HKCUVT
OS: 	Win32NT 10.0.17134.228
64-Bit: True
Domain: DESKTOP-1HKCUVT
User: 	daddycocoaman
Date: 	10/25/2018 5:41:57 PM
```