### PR TITLE
Added feature: Processlist module (ps) & tiny bug fix

### DIFF
--- a/Server/core/loader.py
+++ b/Server/core/loader.py
@@ -20,6 +20,7 @@ class Loader:
         return module
 
     def get_loadables(self):
+        self.loaded = []
         for path in self.paths:
             for module in os.listdir(path):
                 if module[-3:] == '.py' and not module.startswith("example"):

--- a/Server/core/loader.py
+++ b/Server/core/loader.py
@@ -20,7 +20,6 @@ class Loader:
         return module
 
     def get_loadables(self):
-        self.loaded = []
         for path in self.paths:
             for module in os.listdir(path):
                 if module[-3:] == '.py' and not module.startswith("example"):

--- a/Server/modules/ps.py
+++ b/Server/modules/ps.py
@@ -1,0 +1,11 @@
+class STModule:
+    def __init__(self):
+        self.name = 'ps'
+        self.description = 'Show currently running processes'
+        self.author = 'Mark Bregman <@InfoSec_KB>'
+        self.options = {}
+
+    def payload(self):
+        with open('modules/src/ps.py', 'r') as module_src:
+            src = module_src.read()
+            return src.encode()

--- a/Server/modules/src/ps.py
+++ b/Server/modules/src/ps.py
@@ -1,0 +1,44 @@
+import clr
+clr.AddReference ("System")
+clr.AddReference ("System.Management")
+clr.AddReference("System.Core")
+
+import System.Diagnostics
+import System.Management
+from System import Array
+
+def GetProcessExtraInformation(ProcessId):
+    Query = "Select * From Win32_Process Where ProcessID = " + str(ProcessId)
+    Searcher = System.Management.ManagementObjectSearcher(Query)
+    ProcessList = Searcher.Get()
+    Description = "No Description"
+    Username = "Unknown"
+    for Object in ProcessList:
+        ArgList = Array[str](['', ''])
+        ReturnVal = System.Convert.ToInt32(Object.InvokeMethod("GetOwner", ArgList))
+        if ReturnVal == 0:
+            Username = "%s\\%s" % (ArgList[1], ArgList[0])
+        if Object["ExecutablePath"] is not None:
+            try:
+                Info = System.Diagnostics.FileVersionInfo.GetVersionInfo(Object["ExecutablePath"].ToString())
+                Description = Info.FileDescription
+            except:
+                pass
+    return Username, Description
+
+def ConvertToHumanReadableNumber(Num):
+    for Unit in ['B','KiB','MiB','GiB','TiB','PiB']:
+        if abs(Num) < 1024.0:
+            return "%3.1f%s" % (Num, Unit)
+        else:
+            Num /= 1024.0
+
+ProcessList = System.Diagnostics.Process.GetProcesses()
+
+print("|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|")
+print('| {:<40} | {:<6} | {:<10} | {:<12} | {:<30} | {:<50} |'.format("ProcessName", "PID", "Responsive", "Memory Usage", "ProcessOwner", "Description"))
+print("|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|")
+
+for Process in ProcessList:
+        ExtraInfo = GetProcessExtraInformation(Process.Id)
+        print('| {:<40} | {:<6} | {:<10} | {:<12} | {:<30} | {:<50} |'.format(Process.ProcessName, Process.Id, Process.Responding, ConvertToHumanReadableNumber(Process.PrivateMemorySize64), ExtraInfo[0], ExtraInfo[1]))

--- a/Server/stvenom.py
+++ b/Server/stvenom.py
@@ -74,7 +74,7 @@ def generate_resource_file(stager, listener):
         resource_file.write(f"use {listener.name}\n")
         resource_file.write(f"set BindIP {listener['BindIP']}\n")
         resource_file.write(f"set Port {listener['Port']}\n")
-        resource_file.write("start")
+        resource_file.write("start\n")
         resource_file.write("modules")
 
     print_good(f"Generated resource file: {filename}")


### PR DESCRIPTION
Wrote a module to list the currently running processes, similar to 'ps' in Meterpreter.

The process list is currently (among other things) showing a column with the 'responsive' state of every process. This might be swapped in the future for a more useful 'process integrity level' column.

Also applied a tiny bug fix. The resource file created by 'stvenom.py' contained a line with 'startmodules', because it was missing a newline in between 'start' and 'modules'.