### PR TITLE
Generation of stagers in a custom directory

### DIFF
--- a/core/client/contexts/stagers.py
+++ b/core/client/contexts/stagers.py
@@ -87,7 +87,7 @@ class Stagers:
 
         generated_stager = response.result
 
-        stager_filename = f"./stager.{generated_stager['extension']}"
+        stager_filename = f"{generated_stager['output_path']}stager.{generated_stager['extension']}"
         with open(stager_filename, 'wb') as stager:
             stager.write(generated_stager['output'].encode('latin-1'))
 

--- a/core/teamserver/contexts/stagers.py
+++ b/core/teamserver/contexts/stagers.py
@@ -49,10 +49,20 @@ class Stagers(Loader):
 
         for l in self.teamserver.contexts['listeners'].listeners:
             if l['Name'] == listener_name:
+
+                try: 
+                    output_path = self.selected.options['OutputPath']['Value']
+                except KeyError:
+                    output_path = None
+
+                if not output_path:
+                    output_path = './'
+
                 return {
                     "output": self.selected.generate(l),
                     "suggestions": self.selected.suggestions,
-                    "extension": self.selected.extension
+                    "extension": self.selected.extension,
+                    "output_path": output_path
                 }
 
         raise CmdError(f"No listener running with name '{listener_name}'")

--- a/core/teamserver/stagers/csharp.py
+++ b/core/teamserver/stagers/csharp.py
@@ -10,7 +10,13 @@ class STStager(Stager):
         self.suggestions = ''
         self.extension = 'cs'
         self.author = '@byt3bl33d3r'
-        self.options = {}
+        self.options = {
+            'OutputPath': {
+                'Description'  :   "Generate stager in the specified directory",
+                'Required'      :   False,
+                'Value'         :   "./generated_stagers/"
+            }
+        } 
 
     def generate(self, listener):
         with open('./core/teamserver/data/naga.exe', 'rb') as assembly:

--- a/core/teamserver/stagers/dll.py
+++ b/core/teamserver/stagers/dll.py
@@ -8,7 +8,13 @@ class STStager(Stager):
         self.suggestions = ''
         self.extension = 'dll'
         self.author = '@byt3bl33d3r'
-        self.options = {}
+        self.options = {
+            'OutputPath': {
+                'Description'  :   "Generate stager in the specified directory",
+                'Required'      :   False,
+                'Value'         :   "./generated_stagers/"
+            }
+        }
 
     def generate(self, listener):
         with open('./core/teamserver/data/naga.dll', 'rb') as dll:

--- a/core/teamserver/stagers/exe.py
+++ b/core/teamserver/stagers/exe.py
@@ -8,7 +8,13 @@ class STStager(Stager):
         self.suggestions = ''
         self.extension = 'exe'
         self.author = '@byt3bl33d3r'
-        self.options = {}
+        self.options = {
+            'OutputPath': {
+                'Description'  :   "Generate stager in the specified directory",
+                'Required'      :   False,
+                'Value'         :   "./generated_stagers/"
+            }
+        }
 
     def generate(self, listener):
         with open('./core/teamserver/data/naga.exe', 'rb') as exe:

--- a/core/teamserver/stagers/msbuild.py
+++ b/core/teamserver/stagers/msbuild.py
@@ -10,7 +10,13 @@ class STStager(Stager):
         self.suggestions = ''
         self.extension = 'xml'
         self.author = '@byt3bl33d3r'
-        self.options = {}
+        self.options = {
+            'OutputPath': {
+                'Description'  :   "Generate stager in the specified directory",
+                'Required'      :   False,
+                'Value'         :   "./generated_stagers/"
+            }
+        }
 
     def generate(self, listener):
         with open('./core/teamserver/data/naga.exe', 'rb') as assembly:

--- a/core/teamserver/stagers/posh.py
+++ b/core/teamserver/stagers/posh.py
@@ -15,6 +15,11 @@ class STStager(Stager):
                 'Description'   :   "Generate stager as a PowerShell function",
                 'Required'      :   False,
                 'Value'         :   True
+            },
+            'OutputPath': {
+                'Description'  :   "Generate stager in the specified directory",
+                'Required'      :   False,
+                'Value'         :   "./generated_stagers/"
             }
         }
 

--- a/core/teamserver/stagers/wmic.py
+++ b/core/teamserver/stagers/wmic.py
@@ -7,7 +7,13 @@ class STStager(Stager):
         self.suggestions = ''
         self.extension = 'xsl'
         self.author = '@byt3bl33d3r'
-        self.options = {}
+        self.options = {
+            'OutputPath': {
+                'Description'  :   "Generate stager in the specified directory",
+                'Required'      :   False,
+                'Value'         :   "./generated_stagers/"
+            }
+        }
 
     def generate(self, listener):
         with open('core/teamserver/stagers/templates/wmic.xsl') as template:

--- a/generated_stagers/.gitignore
+++ b/generated_stagers/.gitignore
@@ -1,0 +1,9 @@
+# This .gitignore is useful as we can't push an empty directory
+
+# The .gitignore is the only file of this directoty 
+# which needs to be push
+
+*
+!.gitignore
+
+


### PR DESCRIPTION
Before this commit, stagers were generated in the SILENTTRINITY's root
directory. This commit adds an option allowing the user to choose the
location of the generated stager. This commit introduces a new directory
named "generated_stagers/" which is set as the new default directory for
stager generation.