### PR TITLE
Fixing the shell module

### DIFF
--- a/core/teamserver/modules/boo/src/shell.boo
+++ b/core/teamserver/modules/boo/src/shell.boo
@@ -24,10 +24,14 @@ public static def ShellExecute(ShellCommand as string, Path as string, Username 
     shellProcess.StartInfo.UseShellExecute = false
     shellProcess.StartInfo.CreateNoWindow = true
     shellProcess.StartInfo.RedirectStandardOutput = true
-    shellProcess.Start()
 
-    output = shellProcess.StandardOutput.ReadToEnd()
-    shellProcess.WaitForExit()
+    try:
+        shellProcess.Start()
+
+        output = shellProcess.StandardOutput.ReadToEnd()
+        shellProcess.WaitForExit()
+    except e:
+        output = e.Message
 
     return output
 


### PR DESCRIPTION
The shell module wasn't very stable and could make the stager crash :

#### Issue 1 : 

- If the specified **Command** wasn't correct the stager crashed after 1 or 2 minutes : 

![image](https://user-images.githubusercontent.com/44119463/63695131-4857e180-c818-11e9-8ff6-df3b69cbed9c.png)
![image](https://user-images.githubusercontent.com/44119463/63695079-29f1e600-c818-11e9-9dc2-94f9b2d0577b.png)

#### Fix :
- This issue is fixed in this pull request by surrounding the call to shellProcess.Start() with a try/except structure.
