### PR TITLE
Added .rstrip('\n') to convert_shellcode function

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -33,6 +33,7 @@ def shellcode_to_hex_byte_array(shellcode):
 
 # Stolen from https://github.com/zerosum0x0/koadic/blob/master/core/plugin.py
 def convert_shellcode(shellcode):
+    shellcode = shellcode.rstrip('\n')
     decis = []
     count = 0
     for i in range(0, len(shellcode), 2):


### PR DESCRIPTION
Module: boo/excelshellinject
File: core/utils.py
Python Version: 3.7.4

When running the module, I get this error from teamserver:
   
    Traceback (most recent call last):
      File "/home/x/RED/SILENTTRINITY/core/teamserver/jobs.py", line 31, in get
        job_payload = job.payload()
      File "/home/x/RED/SILENTTRINITY/core/teamserver/job.py", line 22, in payload
        "source": self.module.payload(),
      File "core/teamserver/modules/boo/excelshellinject.py", line 30, in payload
        module = module.replace('~SHELLCODEDECCSV~', convert_shellcode(shellcode.read()))
      File "/home/x/RED/SILENTTRINITY/core/utils.py", line 41, in convert_shellcode
        deci = int(hexa, 16)
    ValueError: invalid literal for int() with base 16: '\n'

Reproducing the issue
With some shellcode in 'aabbcc' format, placed at /tmp/shellcode :

    bug.py:
        def convert_shellcode(shellcode):
            decis = []
            count = 0
            for i in range(0, len(shellcode), 2):
                count += 1
                hexa = shellcode[i:i + 2]
                deci = int(hexa, 16)

                if count % 25 == 0:
                    decis.append(" _\\n" + str(deci))
                else:
                    decis.append(str(deci))

            return ",".join(decis)

        with open("/tmp/shellcode", 'r') as shellcode:
            SHELLCODEDECCSV = convert_shellcode(shellcode.read())
            print(SHELLCODEDECCSV)

    Output:
        Λ [~] » python bug.py
        Traceback (most recent call last):
          File "bug.py", line 17, in <module>
            SHELLCODEDECCSV = convert_shellcode(shellcode.read())
          File "bug.py", line 7, in convert_shellcode
            deci = int(hexa, 16)
        ValueError: invalid literal for int() with base 16: '\n'
        Λ [~] »


Fix
The .read() method adds a '\n' at the end, and the convert_shellcode functions does not like being fed that. Add {shellcode = shellcode.rstrip('\n')} in the beggining of the convert_shellcode function to prevent this error :

    fix.py:
        def convert_shellcode(shellcode):
            shellcode = shellcode.rstrip('\n')
            decis = []
            count = 0
            for i in range(0, len(shellcode), 2):
                count += 1
                hexa = shellcode[i:i + 2]
                deci = int(hexa, 16)

                if count % 25 == 0:
                    decis.append(" _\\n" + str(deci))
                else:
                    decis.append(str(deci))

            return ",".join(decis)

        with open("/tmp/shellcode", 'r') as shellcode:
            SHELLCODEDECCSV = convert_shellcode(shellcode.read())
            print(SHELLCODEDECCSV)

    Output:
        Λ [~] » python fix.py
        170,187,204
        Λ [~] »
