### PR TITLE
Minor improvement on module: boo/excelshellinject

### DIFF
--- a/core/client/cmdloop.py
+++ b/core/client/cmdloop.py
@@ -58,14 +58,13 @@ class STCompleter(Completer):
 
                 if self.cli_menu.teamservers.selected:
                     if cmd_line[0] == 'use':
-                        if hasattr(self.cli_menu.current_context, 'available'):
-                            for loadable in self.cli_menu.current_context.available:
-                                if word_before_cursor in loadable:
-                                    # Apperently document.get_word_before_cursor() breaks if there's a forward slash in the command line ?
-                                    try:
-                                        yield Completion(loadable, -len(cmd_line[1]))
-                                    except IndexError:
-                                        yield Completion(loadable, -len(word_before_cursor))
+                        for loadable in self.cli_menu.current_context.available:
+                            if word_before_cursor in loadable:
+                                # Apperently document.get_word_before_cursor() breaks if there's a forward slash in the command line ?
+                                try:
+                                    yield Completion(loadable, -len(cmd_line[1]))
+                                except IndexError:
+                                    yield Completion(loadable, -len(word_before_cursor))
                         return
 
                     if hasattr(self.cli_menu.current_context, 'selected') and self.cli_menu.current_context.selected:

--- a/core/client/cmdloop.py
+++ b/core/client/cmdloop.py
@@ -58,13 +58,14 @@ class STCompleter(Completer):
 
                 if self.cli_menu.teamservers.selected:
                     if cmd_line[0] == 'use':
-                        for loadable in self.cli_menu.current_context.available:
-                            if word_before_cursor in loadable:
-                                # Apperently document.get_word_before_cursor() breaks if there's a forward slash in the command line ?
-                                try:
-                                    yield Completion(loadable, -len(cmd_line[1]))
-                                except IndexError:
-                                    yield Completion(loadable, -len(word_before_cursor))
+                        if hasattr(self.cli_menu.current_context, 'available'):
+                            for loadable in self.cli_menu.current_context.available:
+                                if word_before_cursor in loadable:
+                                    # Apperently document.get_word_before_cursor() breaks if there's a forward slash in the command line ?
+                                    try:
+                                        yield Completion(loadable, -len(cmd_line[1]))
+                                    except IndexError:
+                                        yield Completion(loadable, -len(word_before_cursor))
                         return
 
                     if hasattr(self.cli_menu.current_context, 'selected') and self.cli_menu.current_context.selected:

--- a/core/teamserver/modules/boo/excelshellinject.py
+++ b/core/teamserver/modules/boo/excelshellinject.py
@@ -13,7 +13,7 @@ class STModule(Module):
         self.references = ["Microsoft.Office.Interop.Excel"]
         self.options = {
             'Shellcode': {
-                'Description'   :   'Path to shellcode in ASCII hex format (e.g.: 31c0c3)',
+                'Description'   :   'Path to shellcode in ASCII hex format (e.g.: 31c0c3 or \\x31\\xc0\\xc3)',
                 'Required'      :   True,
                 'Value'         :   ''
             }

--- a/core/utils.py
+++ b/core/utils.py
@@ -31,8 +31,9 @@ def shellcode_to_hex_byte_array(shellcode):
 
     return ','.join(byte_array)
 
-# Stolen from https://github.com/zerosum0x0/koadic/blob/master/core/plugin.py
+# Stolen and adapted from https://github.com/zerosum0x0/koadic/blob/master/core/plugin.py
 def convert_shellcode(shellcode):
+    shellcode = shellcode.translate({ord(c): None for c in '\\x'}).rstrip('\n')
     decis = []
     count = 0
     for i in range(0, len(shellcode), 2):


### PR DESCRIPTION
Flexible ASCII shellcode input: strips trailing '\n', and  '\xDE\xAD' is equivalent to 'dead'.