### PR TITLE
fix BCE0022: Cannot convert 'Boo.Lang.List' to 'Boo.Lang.List' error in modules/ps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ hpack==3.0.0
 hypercorn==0.9.0
 hyperframe==5.2.0
 idna==2.8
+impacket==0.9.20
 itsdangerous==1.1.0
 jinja2==2.10.3
 ldap3==2.5.1

--- a/silenttrinity/core/teamserver/modules/boo/src/ps.boo
+++ b/silenttrinity/core/teamserver/modules/boo/src/ps.boo
@@ -163,9 +163,9 @@ public static class ProcessInspector:
 
     public static def IsCLRLoaded(process as Process) as bool:
         try:
-            modules as List
+            modules as (ProcessModule)
 
-            modules = [module for module in process.Modules.OfType[of ProcessModule]()]
+            modules = [module for module in process.Modules.OfType[of ProcessModule]()].ToArray(ProcessModule)
 
             return modules.Any({ pm as duck| return pm.ModuleName.Contains('mscor')})
         //Access was denied


### PR DESCRIPTION
Boo.Lang.List did not work for some reason (idk why, i am not a BooLang expert ;), but converting the List to Array solved the issue.

(+1 minor addon in requirements.txt to make listeners/wmi available)
