### PR TITLE
Fix run file bug

### DIFF
--- a/silenttrinity/core/client/event_handlers.py
+++ b/silenttrinity/core/client/event_handlers.py
@@ -1,9 +1,15 @@
 import logging
 from silenttrinity.core.utils import print_bad, print_good, print_info
+from pathlib import Path
+from json import dumps
 
 class ClientEventHandlers:
     def __init__(self, connection):
         self.connection = connection
+        self.st_dir = Path('~/.st').expanduser()
+        if not self.st_dir.exists():
+            self.st_dir.mkdir(parents=True)
+
 
     def stats_update(self, data):
         logging.debug(f"In stats_update event handler, got: {data}")
@@ -30,3 +36,12 @@ class ClientEventHandlers:
     def job_result(self, data):
         print_info(f"[{self.connection.alias}] {data['session']} returned job result (id: {data['id']})")
         print(data['output'])
+        
+        # Save results locally
+        results_dir = self.st_dir.joinpath('client', data['session'])
+
+        if not results_dir.exists():
+            results_dir.mkdir(parents=True)
+
+        res_file = results_dir.joinpath(f"{data['id']}.log")
+        res_file.write_text(dumps(data, indent=4))

--- a/silenttrinity/core/teamserver/db.py
+++ b/silenttrinity/core/teamserver/db.py
@@ -55,6 +55,7 @@ class STDatabase:
                             "id" integer PRIMARY KEY,
                             "guid" text,
                             "psk" text,
+                            "alias" text,
                             UNIQUE(guid,psk)
                         )''')
 
@@ -79,6 +80,11 @@ class STDatabase:
             query = self.db.execute("SELECT psk FROM sessions WHERE guid=(?)", [str(guid)])
             result = query.fetchone()
             return result[0] if result else None
+
+    def rename_session(self, guid, alias):
+        with self.db:
+            self.db.execute("UPDATE sessions set alias=(?) WHERE guid=(?)", [str(alias), str(guid)])
+            
 
     def get_sessions(self):
         with self.db:

--- a/silenttrinity/core/teamserver/jobs.py
+++ b/silenttrinity/core/teamserver/jobs.py
@@ -59,6 +59,8 @@ class Jobs:
         elif job.command:
             self.session.logger.info(f"{self.session.guid} returned command result (id: {job_id}): {output}")
 
+        self.session.save_job_result(job_id, output)
+
         #job.status = 'completed'
         return decrypted_job, output
 

--- a/silenttrinity/core/teamserver/session.py
+++ b/silenttrinity/core/teamserver/session.py
@@ -9,6 +9,8 @@ from silenttrinity.core.utils import get_path_in_data_folder, get_path_in_packag
 from silenttrinity.core.teamserver.jobs import Jobs
 from silenttrinity.core.teamserver.comms.utils import gen_stager_code
 from silenttrinity.core.teamserver.crypto import ECDHE
+from json import dumps
+from pathlib import Path
 
 
 class SessionNotFoundError(Exception):
@@ -92,6 +94,18 @@ class Session:
                             zip_file.writestr("Main.boo", stage)
 
         return self.crypto.encrypt(stage_file.getvalue())
+
+    def save_job_result(self, job_id, data):
+
+        results_path = Path(get_path_in_data_folder("logs"), f"{self._guid}", "job_results")
+        if not results_path.exists():
+            results_path.mkdir(parents=True)
+        res_file = results_path.joinpath(f"{job_id}.res")
+        output = dict()
+        output['job_id'] = job_id
+        output['results'] = data
+
+        res_file.write_text(dumps(output, indent=4))
 
     def __str__(self):
         return f"<Session {self._guid}{f' alias: {self._alias}' if self._alias else ''}>"

--- a/silenttrinity/core/teamserver/session.py
+++ b/silenttrinity/core/teamserver/session.py
@@ -16,9 +16,9 @@ class SessionNotFoundError(Exception):
 
 
 class Session:
-    def __init__(self, guid, psk):
+    def __init__(self, guid, psk, alias=''):
         self._guid = str(guid)
-        self._alias = str(guid)
+        self._alias = str(alias) if alias else str(guid) 
         self._info = None
         self.address = None
         self.checkin_time = None


### PR DESCRIPTION
When the user provided a resource file with any empty lines or a trailing line ST would error out. I know simply filter out those lines before they are interpreted and for good measure also added the ability to add comment lines in resource files that start with a hash '#'. 